### PR TITLE
update centos source

### DIFF
--- a/virtual-machines/Vagrantfile
+++ b/virtual-machines/Vagrantfile
@@ -8,7 +8,7 @@ domain = 'example'
 def_network = '172.31.0'
 def_ram = '512'
 os_ubuntu = "ubuntu/trusty64"
-os_centos = "chef/centos-6.6"
+os_centos = "bento/centos-6.7"
 
 nodes = [
   { :hostname => 'master', :ip => def_network+'.11', :box => os_centos},


### PR DESCRIPTION
Chef boxes have moved to Bento

[chef](https://atlas.hashicorp.com/chef/) -> [bento](https://atlas.hashicorp.com/bento/)

